### PR TITLE
Mobile UI: Adapt StartOver btn's height to match Reveal's

### DIFF
--- a/app/components/RevealStartOverLine.tsx
+++ b/app/components/RevealStartOverLine.tsx
@@ -48,7 +48,7 @@ export const RevealStartOverLine = () => {
         {/* Start Over w/ Dropdown*/}
         <div className="flex items-center relative">
           <Button
-            className="text-sm py-2 !px-3.5 rounded-r-none"
+            className="text-sm min-[413px]:!py-3 !py-8 !px-3.5 rounded-r-none"
             onClick={() => {
               startOver()
               setCompromisedShown(false)
@@ -61,7 +61,7 @@ export const RevealStartOverLine = () => {
           {/* Dropdown */}
           <Button
             aria-label={seedInputShown ? 'Hide seed input' : 'Show seed input'}
-            className="!py-3.5 !px-1 !ml-0 rounded-l-none relative right-0.5"
+            className="min-[413px]:!py-3.5 !py-8.5 !px-1 !ml-0 rounded-l-none relative right-0.5"
             onClick={() => setSeedInputShown(!seedInputShown)}
             variant="outline"
           >
@@ -75,7 +75,7 @@ export const RevealStartOverLine = () => {
           {/* Seed input */}
           {seedInputShown && (
             <div
-              className="absolute -right-3 top-12 bg-white border border-gray-200 rounded shadow-md flex gap-2 items-center px-3 py-2 z-10"
+              className="absolute -right-3 min-[413px]:top-12 top-23 bg-white border border-gray-200 rounded shadow-md flex gap-2 items-center px-3 py-2 z-10"
               style={{ minWidth: 0 }}
             >
               <IoDiceOutline


### PR DESCRIPTION
- Left: Old on small screens

- Middle: New on small screens
- Right: New on big screens (same as before)

![image](https://github.com/user-attachments/assets/c64c1acc-1e89-4abb-b226-6b9795031262)

Not sure if I like this or not.

The way I did this was pretty manual, not super clean. I found the specific extra padding the right buttons needed to match the left button, and then went in and made it only trigger on the exact pixel breakpoint (413px) where the left button wraps into 3 lines.

This means it's not only a bit tedious, it's also prone to break if anything causes the height of the buttons to change, or when they wrap.

I'm pretty sure there's a much cleaner way possible, where the buttons are set to `height: auto`, and they automatically grow to match the container.

There's also still an in-between state where the left button is 2 lines. I didn't do that one yet. 

But like I said, I'm not even sure if I prefer the look of this change or not.

Wanted to save the progress on it so far, though. Can come back to it later with fresh eyes.