### PR TITLE
Generate compromised votes to have 50/50 odds to flip election

### DIFF
--- a/app/utils/makeElection.ts
+++ b/app/utils/makeElection.ts
@@ -15,11 +15,16 @@ export function makeElection(mt: MT19937): ElectionResults {
   const otherVotes = Math.floor(mt.random() * (winnerVotes * 0.2)) // Other votes up to 20% of winner's votes
   const totalVotes = winnerVotes + runnerUpVotes + otherVotes
 
-  // Generate random compromised percentage between 0 and 100
-  const compromisedPercentage = mt.random() * 100
-  const compromisedVotes = Math.floor(
-    (compromisedPercentage / 100) * totalVotes
-  )
+  // Calculate the margin needed to flip the election
+  // Each compromised vote represents a net swing of 2 votes (-1 from winner, +1 to runner-up)
+  const marginOfVictory = winnerVotes - runnerUpVotes
+  const marginToFlip = marginOfVictory / 2
+
+  // Generate compromised votes to have 50/50 odds to flip election
+  // The compromised votes will be between 0 and 2x the margin needed to flip
+  const maxCompromisedVotes = marginToFlip * 2
+  const compromisedVotes = Math.floor(mt.random() * maxCompromisedVotes)
+  const compromisedPercentage = (compromisedVotes / totalVotes) * 100
 
   return {
     compromisedPercentage,

--- a/app/utils/tests/makeElection.test.ts
+++ b/app/utils/tests/makeElection.test.ts
@@ -67,4 +67,24 @@ describe('makeElection', () => {
     const result2 = makeElection(mt2)
     expect(result2).not.toBeEmptyObject()
   })
+
+  it('should create roughly 50/50 odds of flipping the election', () => {
+    const mt = new MT19937(42)
+    let flips = 0
+    const trials = 10000
+
+    for (let i = 0; i < trials; i++) {
+      const result = makeElection(mt)
+      const marginOfVictory = result.winnerVotes - result.runnerUpVotes
+      const marginToFlip = marginOfVictory / 2
+      if (result.compromisedVotes >= marginToFlip) flips++
+    }
+
+    const flipRate = flips / trials
+    // Should be roughly 50% (allowing for some variance)
+    const variance = 0.02
+    expect(flipRate).toBeGreaterThan(0.5 - variance)
+    expect(flipRate).toBeLessThan(0.5 + variance)
+    expect(flipRate).not.toBe(0.5) // But not exactly 50%
+  })
 })

--- a/app/utils/tests/speedTests.test.ts
+++ b/app/utils/tests/speedTests.test.ts
@@ -86,8 +86,8 @@ describe('speed tests', () => {
   })
 
   const intersectionCases: [string, number, number][] = [
-    ['a300k b1k c50', 148319, 150], // Getting ~90ms
-    // ['a1m b1m', 495555, 1000], // Getting ~700ms
+    ['a300k b1k c50', 34428, 150], // Getting ~90ms
+    // ['a1m b1m', 114574, 1000], // Getting ~700ms
   ]
 
   intersectionCases.forEach(([testCase, expectedCompromises, expectedTime]) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simulate-corrupted-election",
-  "version": "1.3.2",
+  "version": "2.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
The point of this tool is to calibrate detecting whether elections have enough compromised votes to flip the outcome.

## The problem

Currently, the %-Compromised is randomly selected from 0-100%, of the total votes cast: https://github.com/dsernst/simulate-corrupted-election/blob/5f590e46a81d416750ddd278aff4f65f5b3c3618/app/utils/makeElection.ts#L18-L19

But `runnerUpVotes` is also randomly selected from `winnerVotes * rand(0,1)`.

This means the election's "margin of error" gets distributed over a much smaller midpoint. So a majority of the time, the simulator's randomly chosen # of compromised votes will be more than enough to flip the election.

## What should be happening

Ideally, the hidden %-compromised should have a 50/50 chance of flipping the election outcome.

This would make it much harder to simply guess, since there'd be even odds on each side.

This will make it much more clear how well any particular strategy actually performs, vs random chance.

## Impact

- [x] This changes the `compromisedVotes` and `compromisedPercentage` for existing seeds. 
- [ ] So it could count as a [SemVer Major](https://semver.org) breaking change.
- [x] This PR adds good unit tests to confirm this is distributing evenly. Across 10,000 random trials, it now flips 50.17% of them.
- [x] All other unit tests are still passing. There were minor required adjustments to 2 of the speedTest's `expectedCompromises` values — not surprising.
- [x] Looking at new revealed_compromised numbers in the web UI, the % compromises seems to have significantly lowered — as predicted. This makes the numbers look a bit more "realistic". Far fewer cases of extreme over-compromise. That does still happen, but less often.

## Remaining TODO
- [ ] Since this is a "breaking" major change, before deploying, I'd still like to check-in w/ collaborators to minimize disruptions to their existing workflows and work-in-progress.
- [ ] Also still want to bump the Major version number from `1.minor.patch` --> `2.0.0`.